### PR TITLE
JvmArgs based on Operating System

### DIFF
--- a/source/desktop/build.gradle
+++ b/source/desktop/build.gradle
@@ -4,17 +4,27 @@ sourceSets.main.resources.srcDirs = ["../core/assets"]
 project.ext.mainClassName = "com.deco2800.game.desktop.DesktopLauncher"
 project.ext.assetsDir = new File("../core/assets")
 
+import org.gradle.internal.os.OperatingSystem
+
 task run(dependsOn: classes, type: JavaExec) {
     main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
     ignoreExitValue = true
-    // For mac
-    jvmArgs = ["-Djava.util.logging.config.file=../../logging.properties", "-XstartOnFirstThread"]
-    // For windows
-    // jvmArgs = ["-Djava.util.logging.config.file=../../logging.properties"]
 
+
+    String osName = OperatingSystem.current().getName();
+    String osVersion = OperatingSystem.current().getVersion();
+    println "*** $osName $osVersion was detected."
+
+     if (OperatingSystem.current().isMacOsX()) {
+         // OS X.
+         jvmArgs = ["-Djava.util.logging.config.file=../../logging.properties", "-XstartOnFirstThread"]
+    } else {
+         // Windows, Linux etc.
+        jvmArgs = ["-Djava.util.logging.config.file=../../logging.properties"]
+    }
 }
 
 task debug(dependsOn: classes, type: JavaExec) {


### PR DESCRIPTION
Dynamically add jvmArgs based on Operating System. This will add "-XstartOnFirstThread" argument for MacOS users automatically, and omit it for other operating systems. 